### PR TITLE
ie8 Fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Installation and Setup
 **Load the script asynchroneously**::
 
     var init_appenlight = function () {
+      if(this.readyState!='loading'){
           var appenlight_client = new Appenlight();
           window.appenlight_client = appenlight_client;
           appenlight_client.init({
@@ -28,6 +29,7 @@ Installation and Setup
               ip: "127.0.0.1",
               request_id:"server_generated_uuid"
           });
+      }
     };
     //  load the script asynchroneously
     var app_enlight = document.createElement('script');


### PR DESCRIPTION
IE8 runs "onreadystatechange" twice, one for "loading" and another one for "loaded", by checking "this.readyState" we can check if it's already loaded but on chrome, this.readyState, is set as undefined, so the best way is to check if it isn't loading.
teste on Safari(6.0.3),chrome(31.0.1650.57 m), IE8(8.0.6001.18702), Opera(18.0.1284.49 )

another possible fix is by setting the callback function on the js itself.
