### PR TITLE
Version handling and other minor improvements

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,8 +25,8 @@
   // Prohibit use of == and != in favor of === and !==.
   "eqeqeq": true,
 
-  // Enforce tab width of 2 spaces.
-  "indent": 2,
+  // Enforce tab width of 4 spaces.
+  "indent": 4,
 
   // Prohibit use of a variable before it is defined.
   "latedef": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,11 +42,8 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  //grunt.loadNpmTasks("grunt-remove-logging");
+  require('load-grunt-tasks')(grunt);
+
   grunt.loadNpmTasks('grunt-bumpup');
 
   grunt.registerTask('test', ['jshint']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,15 +1,20 @@
 module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    bumpup: {
+      files: ['bower.json', 'package.json']
+    },
     concat: {
       options: {
-        separator: '\n'
+        separator: '\n',
+        // Interpolate grunt template tags (e.g. <%= pkg.version %>)
+        process: true
       },
       dist: {
         src: [
-        "src/appenlight-client.js",
-        "src/tracekit.js",
-    ],
+          'src/appenlight-client.js',
+          'src/tracekit.js',
+        ],
         dest: 'appenlight-client.js'
       }
     },
@@ -42,6 +47,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   //grunt.loadNpmTasks("grunt-remove-logging");
+  grunt.loadNpmTasks('grunt-bumpup');
 
   grunt.registerTask('test', ['jshint']);
 

--- a/README.rst
+++ b/README.rst
@@ -10,52 +10,53 @@ appenlight_client_javascript
 Usage Example
 -------------
 
-## Include the script on your page
+Include the script on your page
+===============================
 
 First, please obtain latest copy of javascript client from our [**Github repository**](https://github.com/AppEnlight/appenlight-client-js).
 
 Or use CDN hosted version from jsDelivr (http://www.jsdelivr.com/#!appenlight).
 
-Next you can include the file on your pages directly or asynchroneously:
+Next you can include the file on your pages directly or asynchronously:
 
 Installation and Setup
 ======================
 
-**Load the script asynchroneously**::
+**Load the script asynchronously**::
 
     var initAppEnlight = function () {
       if(this.readyState!='loading'){
           AppEnlight.init({
-              apiKey:'PUBLIC_API_KEY',
+              apiKey: 'PUBLIC_API_KEY',
               windowOnError: 1 // enable to hook to window.onerror
           });
           // setting request info is completly optional
           AppEnlight.setRequestInfo({
-              server:'servername',
-              username:'i_am_mario',
-              ip: "127.0.0.1",
-              request_id:"server_generated_uuid"
+              server: 'servername',
+              username: 'i_am_mario',
+              ip: '127.0.0.1',
+              request_id: 'server_generated_uuid'
           });
       }
     };
-    //  load the script asynchroneously
+    //  load the script asynchronously
     var scrElem = document.createElement('script');
     scrElem.type = 'text/javascript';
     scrElem.async = true;
     scrElem.onload = scrElem.onreadystatechange = initAppEnlight;
-    scrElem.src = "//cdn.jsdelivr.net/appenlight/0.2.0/appenlight-client.min.js";
+    scrElem.src = '//cdn.jsdelivr.net/appenlight/0.2.0/appenlight-client.min.js';
     var p = document.getElementsByTagName('script')[0];
     p.parentNode.insertBefore(scrElem, p);
 
 
-At this point client is configured and will automaticly stream all data to
+At this point client is configured and will automatically stream all data to
 our servers every 1 second if it has anything in its buffers.
 
 If `windowOnError` config option is enabled the client will process all unhandled
-exceptions for you. Remember though that window.onerror stacks contain minimal amount
-of information, for best results you want to do explict exception catching.
+exceptions for you. Remember though that window.onerror stacks contain a minimal amount
+of information; for best results you want to do explicit exception catching.
 
-Please *avoid* throwing string exceptions, if possible use `throw new Error()` instead.
+Please *avoid* throwing string exceptions; if possible use `throw new Error()` instead.
 
 ** EXPLICIT ERROR CATCHING - EXAMPLE**::
 
@@ -69,6 +70,6 @@ Please *avoid* throwing string exceptions, if possible use `throw new Error()` i
 
 **LOGGING - EXAMPLE**::
 
-    AppEnlight.log('error',"some test message");
-    AppEnlight.log('info',"some info message");
-    AppEnlight.log('warning',"some warn message");
+    AppEnlight.log('error','some test message');
+    AppEnlight.log('info','some info message');
+    AppEnlight.log('warning','some warn message');

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
-  "name": "appenlight",
-  "version": "0.3.2",
+  "name": "appenlight-client",
+  "version": "0.4.2",
   "authors": [
     "Marcin Lulek <info@webreactor.eu>"
   ],
-  "description": "Appenlight JS client",
+  "description": "Javascript client for App Enlight",
   "main": "appenlight-client.js",
   "license": "BSD",
   "homepage": "https://appenlight.com",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "appenlight-client",
+    "version": "0.4.2",
     "description": "Javascript client for App Enlight",
     "devDependencies": {
         "grunt": "",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
     "grunt-contrib-uglify": "",
     "grunt-contrib-watch": "",
     "grunt-remove-logging": "",
+    "load-grunt-tasks": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "appenlight-client",
-    "version": "0.4.2",
-    "description": "Javascript client for App Enlight",
-    "devDependencies": {
-        "grunt": "",
-        "grunt-contrib-jshint": "",
-        "grunt-contrib-nodeunit": "",
-        "grunt-contrib-uglify": "",
-        "grunt-contrib-concat": "",
-        "grunt-contrib-watch": "",
-        "grunt-remove-logging": ""
-    }
+  "name": "appenlight-client",
+  "version": "0.4.2",
+  "description": "Javascript client for App Enlight",
+  "devDependencies": {
+    "grunt": "",
+    "grunt-bumpup": "",
+    "grunt-contrib-concat": "",
+    "grunt-contrib-jshint": "",
+    "grunt-contrib-nodeunit": "",
+    "grunt-contrib-uglify": "",
+    "grunt-contrib-watch": "",
+    "grunt-remove-logging": "",
+  }
 }
-

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -25,7 +25,7 @@
     };
 
     var AppEnlight = {
-        version: '0.4.2',
+        version: '<%= pkg.version %>',
         options: {
             apiKey: ''
         },


### PR DESCRIPTION
I noticed that the version number in bower.json was different than the one hardcoded in the source and was missing from package.json. This pull request primarily cleans up the build process to avoid touching files when bumping the version number. Instead, use `grunt bumpup` to bump a patch version (`grunt bumpup:minor` to bump a minor version, `grunt bumpup:major`, etc). See [grunt-bumpup documentation](https://github.com/darsain/grunt-bumpup). This maintains the same version in package.json and bower.json and the version number in the script is now interpolated by grunt-contrib-concat based on the version in package.json. Just remember to bump then build to avoid an outdated version number in the code.

There are a few other housekeeping items in this pull request like typos and other grunt simplifications. I don't usually like to roll multiple changes into one pull request but I already have a decent number of PRs cooking for actual functionality.