### PR TITLE
Global namespace option

### DIFF
--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -37,6 +37,7 @@
         tags: [],
 
         init: function (options) {
+            options = options || {};
             var self = this;
             if (typeof options.server === 'undefined') {
                 options.server = 'https://api.appenlight.com';
@@ -111,6 +112,14 @@
             for (var i in info) {
                 this.tags.push([i, info[i]]);
             }
+        },
+
+        clearGlobalNamespace: function () {
+            this.options.namespace = undefined;
+        },
+
+        setGlobalNamespace: function (namespace) {
+            this.options.namespace = namespace;
         },
 
         grabError: function (exception, options) {
@@ -213,7 +222,12 @@
         },
         log: function (level, message, namespace, uuid) {
             if (typeof namespace === 'undefined') {
-                namespace = window.location.pathname;
+                if (typeof this.options.namespace !== 'undefined') {
+                    namespace = this.options.namespace;
+                }
+                else {
+                    namespace = window.location.pathname;
+                }
             }
             if (typeof uuid === 'undefined') {
                 uuid = null;


### PR DESCRIPTION
This pull request adds a `namespace` option to the `init` call as well as a few explicit methods to set and clear the global namespace. When the global value is `undefined` (the default) the client will still use the URL pathname as the namespace. As with the namespace argument on the `log` method, `null` can be used to prevent application of that default namespace. 

The namespace is applied to logs; I did not see a namespace specified for errors.