### PR TITLE
Added log tags

### DIFF
--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -238,7 +238,8 @@
                     'log_level': level.toUpperCase(),
                     'message': message,
                     'date': new Date().toJSON(),
-                    'namespace': namespace
+                    'namespace': namespace,
+                    'request_id': uuid
                 });
             if (this.requestInfo !== null && typeof this.requestInfo.server !== 'undefined') {
                 this.logBuffer[this.logBuffer.length - 1].server = this.requestInfo.server;

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -33,7 +33,7 @@
         errorReportBuffer: [],
         slowReportBuffer: [],
         logBuffer: [],
-        requestInfo: null,
+        requestInfo: {},
         extraInfo: [],
         tags: [],
 
@@ -70,7 +70,6 @@
                 this.options[k] = options[k];
             }
 
-            this.requestInfo = {url: window.location.href};
             this.reportsEndpoint = options.server +
                 '/api/reports?public_api_key=' + this.options.apiKey +
                 '&protocolVersion=' + this.options.protocolVersion;
@@ -160,7 +159,8 @@
                 'request': {},
                 'traceback': [],
                 'extra': [],
-                'tags': []
+                'tags': [],
+                'url': window.location.href
             };
             report.user_agent = window.navigator.userAgent;
             report.start_time = new Date().toJSON();

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -168,11 +168,11 @@
             }
 
             if (this.extraInfo !== null) {
-                report.extra = this.extraInfo;
+                report.extra = report.extra.concat(this.extraInfo);
             }
 
             if (this.tags !== null) {
-                report.tags = this.tags;
+                report.tags = report.tags.concat(this.tags);
             }
 
             if (options && typeof options.extra !== 'undefined'){

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -65,7 +65,11 @@
             if (options.sendInterval >= 1000) {
                 this.createSendInterval(options.sendInterval);
             }
-            this.options = options;
+
+            for (var k in options) {
+                this.options[k] = options[k];
+            }
+
             this.requestInfo = {url: window.location.href};
             this.reportsEndpoint = options.server +
                 '/api/reports?public_api_key=' + this.options.apiKey +

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -229,7 +229,7 @@
             }
             this.errorReportBuffer.push(report);
         },
-        log: function (level, message, namespace, uuid) {
+        log: function (level, message, namespace, uuid, tags) {
             if (typeof namespace === 'undefined') {
                 if (typeof this.options.namespace !== 'undefined') {
                     namespace = this.options.namespace;
@@ -241,17 +241,28 @@
             if (typeof uuid === 'undefined') {
                 uuid = null;
             }
-            this.logBuffer.push(
-                {
-                    'log_level': level.toUpperCase(),
-                    'message': message,
-                    'date': new Date().toJSON(),
-                    'namespace': namespace,
-                    'request_id': uuid
-                });
-            if (this.requestInfo !== null && typeof this.requestInfo.server !== 'undefined') {
-                this.logBuffer[this.logBuffer.length - 1].server = this.requestInfo.server;
+            var logInfo = {
+                'log_level': level.toUpperCase(),
+                'message': message,
+                'date': new Date().toJSON(),
+                'namespace': namespace,
+                'request_id': uuid
+            };
+
+            if (this.requestInfo && typeof this.requestInfo.server !== 'undefined') {
+                logInfo.server = this.requestInfo.server;
             }
+
+            if ((tags && tags.length > 0) || this.tags.length > 0) {
+                logInfo.tags = [].concat(this.tags);
+                if (tags) {
+                    for (var i in tags) {
+                        logInfo.tags.push([i, tags[i]]);
+                    }
+                }
+            }
+
+            this.logBuffer.push(logInfo);
         },
 
         genUUID4: function () {

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -92,6 +92,10 @@
             }, timeIv);
         },
 
+        clearRequestInfo: function () {
+            this.requestInfo = {};
+        },
+
         setRequestInfo: function (info) {
             for (var i in info) {
                 this.requestInfo[i] = info[i];


### PR DESCRIPTION
This pull request is based on the bug-fixes branch; please merge bug-fixes first. This simply adds the `tags` parameter to `log()` and sends it along with the global tags. I think I still prefer the single `options` argument in place of `namespace, uuid, tags` but this is an appropriate incremental change in that direction.

As with reports, the tags for logging are not de-duplicated. For the sake of curiosity would the backend handle a case like `[["a": 5], ["a": 6]]` as `{ a: 5 }` or `{ a: 6 }`?