### PR TITLE
Simplify storage of global tags and extra to improve editability

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,7 +29,7 @@
   "indent": 4,
 
   // Prohibit use of a variable before it is defined.
-  "latedef": true,
+  "latedef": "nofunc",
 
   // Enforce line length to 100 characters
   "maxlen": 100,

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -113,6 +113,7 @@
         },
 
         handleError: function (errorReport, options) {
+            options = options || {};
             /*jshint camelcase: false */
             var errorMsg = '';
             if (errorReport.mode === 'stack') {

--- a/src/appenlight-client.js
+++ b/src/appenlight-client.js
@@ -1,28 +1,6 @@
 (function (window) {
     'use strict';
 
-    var buildContextString = function (contextLines) {
-        var context = '';
-        if (contextLines) {
-            for (var k = 0; k < contextLines.length; k++) {
-                try{
-                    var line = contextLines[k];
-                    if (line.length > 300) {
-                        context += '<minified-context>';
-                    }
-                    else {
-                        context += line;
-                    }
-
-                }
-                catch(exc){
-                    context += '<error-parsing-context>';
-                }
-                context += '\n';
-            }
-        }
-        return context;
-    };
     var logLevels = ['debug', 'info', 'warning', 'error', 'critical'];
 
     var AppEnlight = {
@@ -275,6 +253,34 @@
             }
         }
         return target;
+    }
+
+    // Given an array of context lines, format as a string with one per lines
+    function buildContextString(contextLines) {
+        if (contextLines) {
+            var context = new Array(contextLines.length + 1);
+            
+            for (var k = 0; k < contextLines.length; k++) {
+                try{
+                    var line = contextLines[k];
+                    if (line.length > 300) {
+                        context[k] = '<minified-context>';
+                    }
+                    else {
+                        context[k] = line;
+                    }
+
+                }
+                catch(exc){
+                    context[k] = '<error-parsing-context>';
+                }
+            }
+            // Join will include a trailing \n if there are context lines
+            context[k] = '';
+
+            return context.join('\n');
+        }
+        return '';
     }
 
     // Determine whether a property with the specified key is defined in the


### PR DESCRIPTION
I noticed that storing tags and extra as an array prevents removal or updating of a specific key without adding a new entry to the array. Consider the following example:

```
$('#button1').click(function() { AppEnlight.addGlobalTags({ button: 1 }); });
$('#button2').click(function() { AppEnlight.addGlobalTags({ button: 2 }); });
```

A developer might expect that clicking button 1 causes the `button: 1` tag to be sent with future logs and clicking button 2 causes the `button: 2` tag to be sent. However, the actual data transmitted to the backend will be `[["button":1]]` followed by `[["button":1],["button":2]]`. Since the backend uses only the last value you will correctly see `button: 2` in AppEnlight, but there is an expense incurred for the unnecessary `["button":1]` chunk. If the user keeps clicking these buttons eventually we are sending *a lot* of unnecessary data to the backend. This pull request eliminates that networking overhead by ensuring only one value is sent per key and also makes the global tags and extra easier to use.

With this change, `extraInfo` and `tags` are stored as objects rather than arrays. Adding the same tag a second time simply overwrites the previous value. The serialization to key value pairs happens only when the logs and reports are sent. Since both the global and local tags are objects it is easy to merge them to avoid duplicates at that level as well.

Additionally, a `keys` parameter was added to `clearGlobalExtra` and `clearGlobalTags` to allow specific keys to be deleted outright without wiping out the entire object. The `assign` function was used in a few other places that were unsafely iterating objects or verbosely checking and assigning individual keys.

This pair serialization is a bit more work for the client on each log and report. A performance optimization would be to keep a serialized copy of the `extraInfo` and `tags` and update it only when the add or clear methods are called. However, since `extraInfo` and `tags` are properties of `AppEnlight` I can imagine developers editing those properties directly and then not understanding why the values they set are not sent to the backend. If a serialized copy is maintained in that way, the associated variables would need to be private (defined in the outer function scope similar to `logLevels`).