### PR TITLE
Added main path for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "appenlight-client",
   "version": "0.4.2",
   "description": "Javascript client for App Enlight",
+  "main": "appenlight-client.js",
   "devDependencies": {
     "grunt": "",
     "grunt-bumpup": "",


### PR DESCRIPTION
Bundling this with npm and webpack, it's easiest if package.json references the main file. Same as bower.json now.