### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Installation and Setup
     scrElem.type = 'text/javascript';
     scrElem.async = true;
     scrElem.onload = scrElem.onreadystatechange = initAppEnlight;
-    scrElem.src = '//cdn.jsdelivr.net/appenlight/0.2.0/appenlight-client.min.js';
+    scrElem.src = '//cdn.jsdelivr.net/gh/AppEnlight/appenlight-client-js@0.5.1/appenlight-client.min.js';
     var p = document.getElementsByTagName('script')[0];
     p.parentNode.insertBefore(scrElem, p);
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/AppEnlight/appenlight-client-js.

Feel free to ping me if you have any questions regarding this change.